### PR TITLE
chore: bump go version to 1.18

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-28T16:27:48Z by kres b8587b7-dirty.
+# Generated on 2022-03-31T15:34:50Z by kres ff0aee3-dirty.
 
 ---
 policies:
@@ -10,7 +10,7 @@ policies:
     gpg:
       required: true
       identity:
-        gitHubOrganization: talos-systems
+        gitHubOrganization: siderolabs
     spellcheck:
       locale: US
     maximumOfOneCommit: true
@@ -34,7 +34,4 @@ policies:
     excludeSuffixes:
       - .pb.go
       - .pb.gw.go
-    header: |
-      // This Source Code Form is subject to the terms of the Mozilla Public
-      // License, v. 2.0. If a copy of the MPL was not distributed with this
-      // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    header: "// This Source Code Form is subject to the terms of the Mozilla Public\u000A// License, v. 2.0. If a copy of the MPL was not distributed with this\u000A// file, You can obtain one at http://mozilla.org/MPL/2.0/.\u000A"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-28T16:15:29Z by kres b8587b7.
+# Generated on 2022-03-31T15:34:50Z by kres ff0aee3-dirty.
 
 # options for analysis running
 run:
@@ -132,6 +132,7 @@ linters:
     - tagliatelle
     - thelper
     - typecheck
+    - varnamelen
     - wrapcheck
     # abandoned linters for which golangci shows the warning that the repo is archived by the owner
     - interfacer

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-28T16:15:29Z by kres b8587b7.
+# Generated on 2022-03-31T15:34:50Z by kres ff0aee3-dirty.
 
 ARG TOOLCHAIN
 
 # cleaned up specs and compiled versions
 FROM scratch AS generate
 
-FROM ghcr.io/talos-systems/ca-certificates:v0.3.0-12-g90722c3 AS image-ca-certificates
+FROM ghcr.io/siderolabs/ca-certificates:v1.0.0 AS image-ca-certificates
 
-FROM ghcr.io/talos-systems/fhs:v0.3.0-12-g90722c3 AS image-fhs
+FROM ghcr.io/siderolabs/fhs:v1.0.0 AS image-fhs
 
 # runs markdownlint
 FROM node:14.8.0-alpine AS lint-markdown
@@ -31,7 +31,7 @@ FROM toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.42.1
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.45.2
 ARG GOFUMPT_VERSION
 RUN go install mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
 	&& mv /go/bin/gofumports /bin/gofumports
@@ -88,6 +88,6 @@ ARG TARGETARCH
 COPY --from=importvet importvet-linux-${TARGETARCH} /importvet
 COPY --from=image-fhs / /
 COPY --from=image-ca-certificates / /
-LABEL org.opencontainers.image.source https://github.com/talos-systems/importvet
+LABEL org.opencontainers.image.source https://github.com/siderolabs/importvet
 ENTRYPOINT ["/importvet"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-28T16:15:29Z by kres b8587b7.
+# Generated on 2022-03-31T15:34:50Z by kres ff0aee3-dirty.
 
 # common variables
 
@@ -9,16 +9,16 @@ TAG := $(shell git describe --tag --always --dirty)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
 REGISTRY ?= ghcr.io
-USERNAME ?= talos-systems
+USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
-GO_VERSION ?= 1.17
-PROTOBUF_GO_VERSION ?= 1.27.1
-GRPC_GO_VERSION ?= 1.1.0
-GRPC_GATEWAY_VERSION ?= 2.4.0
-VTPROTOBUF_VERSION ?= 81d623a9a700ede8ef765e5ab08b3aa1f5b4d5a8
+GO_VERSION ?= 1.18
+PROTOBUF_GO_VERSION ?= 1.28.0
+GRPC_GO_VERSION ?= 1.2.0
+GRPC_GATEWAY_VERSION ?= 2.10.0
+VTPROTOBUF_VERSION ?= d8520340f57329767fd3b2c9cc0aea3703dd68c9
 TESTPKGS ?= ./...
-KRES_IMAGE ?= ghcr.io/talos-systems/kres:latest
+KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 
 # docker build settings
 
@@ -42,7 +42,7 @@ COMMON_ARGS += --build-arg=GRPC_GO_VERSION=$(GRPC_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION=$(GRPC_GATEWAY_VERSION)
 COMMON_ARGS += --build-arg=VTPROTOBUF_VERSION=$(VTPROTOBUF_VERSION)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
-TOOLCHAIN ?= docker.io/golang:1.17-alpine
+TOOLCHAIN ?= docker.io/golang:1.18-alpine
 
 # help menu
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,11 +2,11 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-10-28T16:15:29Z by kres b8587b7.
+# Generated on 2022-03-31T15:34:50Z by kres ff0aee3-dirty.
 
 set -e
 
-RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+RELEASE_TOOL_IMAGE="ghcr.io/siderolabs/release-tool:latest"
 
 function release-tool {
   docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null

--- a/pkg/importvet/importvet.go
+++ b/pkg/importvet/importvet.go
@@ -52,7 +52,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	if packagePath == "" {
 		// package path wasn't discovered, skip it
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	configs, err := configTree.Match(packagePath)
@@ -93,7 +93,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		pass.ExportPackageFact(&fact)
 	}
 
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }
 
 func imported(info *types.Info, spec *ast.ImportSpec) *types.Package {
@@ -102,5 +102,5 @@ func imported(info *types.Info, spec *ast.ImportSpec) *types.Package {
 		obj = info.Defs[spec.Name] // renaming import
 	}
 
-	return obj.(*types.PkgName).Imported()
+	return obj.(*types.PkgName).Imported() //nolint:forcetypeassert
 }

--- a/pkg/importvet/tree.go
+++ b/pkg/importvet/tree.go
@@ -61,7 +61,7 @@ func (cfgTree *ConfigTree) Match(path string) ([]*Config, error) {
 	var configs []*Config
 
 	err := cfgTree.configTrie.WalkPath(path, func(key string, value interface{}) error {
-		configs = append(configs, value.(*Config))
+		configs = append(configs, value.(*Config)) //nolint:forcetypeassert
 
 		return nil
 	})


### PR DESCRIPTION
Update Go compiler to 1.18

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>